### PR TITLE
Bugfix/is int missing is numeric filter

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -7,8 +7,8 @@ Ed Finkler
 <http://inspekt.org>    
 <http://github.com/funkatron/inspekt>    
 
-**Version 0.6.0**
-**2015-09-23**
+**Version 0.6.1**
+**2016-03-03**
 
 
 ## What Is Inspekt?
@@ -125,6 +125,10 @@ Visit the Github site for Inspekt at <http://github.com/funkatron/inspekt>
 
 
 ## Changelog ##
+
+### Version 0.6.1 - 2016-03-03 ###
+
+- Bug fix for isFloat()
 
 ### Version 0.6.0 - 2014-11-08 ###
 

--- a/src/Inspekt/Inspekt.php
+++ b/src/Inspekt/Inspekt.php
@@ -803,7 +803,7 @@ class Inspekt
          * we exit here if not is_numeric, because str_replace below will cast bools
          * to numerics
          */
-        if (is_object($value) || is_bool($value)) {
+        if (is_object($value) || is_bool($value) || !is_numeric($value)) {
             return false;
         }
 

--- a/tests/InspektTest.php
+++ b/tests/InspektTest.php
@@ -751,6 +751,60 @@ class InspektTest extends PHPUnit_Framework_TestCase
     /**
      *
      */
+    public function testIsInt5()
+    {
+        $input = "";
+        $this->assertFalse(Inspekt::isInt($input));
+    }
+
+    /**
+     *
+     */
+    public function testIsInt6()
+    {
+        $input = "123abg";
+        $this->assertFalse(Inspekt::isInt($input));
+    }
+
+    /**
+     *
+     */
+    public function testIsInt7()
+    {
+        $input = "abg123";
+        $this->assertFalse(Inspekt::isInt($input));
+    }
+
+    /**
+     *
+     */
+    public function testIsInt8()
+    {
+        $input = "0x1234cafe";
+        $this->assertFalse(Inspekt::isInt($input));
+    }
+
+    /**
+     *
+     */
+    public function testIsInt9()
+    {
+        $input = "-";
+        $this->assertFalse(Inspekt::isInt($input));
+    }
+
+    /**
+     *
+     */
+    public function testIsInt10()
+    {
+        $input = "&";
+        $this->assertFalse(Inspekt::isInt($input));
+    }
+
+    /**
+     *
+     */
     public function testIsIp()
     {
         $input = '192.168.1.1';


### PR DESCRIPTION
Version 0.6.1
Inspekt.php
isInt() function
We expect that isInt() would return false when the empty string is passed in, but because isInt() is missing the is_numeric() test, it returns true.
Here's the comment that makes it look like is_numeric() was intended, but maybe forgotten:
802         /**
803          * we exit here if not is_numeric, because str_replace below will cast bools
804          * to numerics
805          */
Line 806 is missing the is_numeric() check. Here's what it might look like:
806         if (is_object($value) || is_bool($value) || !is_numeric($value)) {
The tests/InspektTest.php file has no tests that test for non-numbers.
A test for the empty string and a few other non-integer strings would be appropriate.
Thanks for considering this.