### PR TITLE
Fixed array_key_exists using ArrayObject instead of array

### DIFF
--- a/src/Inspekt/Cage.php
+++ b/src/Inspekt/Cage.php
@@ -940,7 +940,7 @@ class Cage implements \IteratorAggregate, \ArrayAccess, \Countable
             $keys = explode(self::ISPK_ARRAY_PATH_SEPARATOR, $key);
             return $this->keyExistsRecursive($keys, $this->source);
         } else {
-            return $exists = array_key_exists($key, $this->source);
+            return $exists = array_key_exists($key, (array) $this->source);
         }
     }
 


### PR DESCRIPTION
Fix for PHP8: funkatron/inspekt/src/Inspekt/Cage.php(943) -- array_key_exists(): Argument #2 ($array) must be of type array, ArrayObject given

fixed #18 